### PR TITLE
Add option to not send game version informations

### DIFF
--- a/pvpgn/src/client/bnstat.cpp
+++ b/pvpgn/src/client/bnstat.cpp
@@ -97,6 +97,7 @@ void usage(char const * progname)
     std::fprintf(stderr,
 	    "    -o NAME, --owner=NAME       report CD owner as NAME\n"
 	    "    -k KEY, --cdkey=KEY         report CD key as KEY\n"
+	    "    -i, --ignore-version        ignore version request (do not send game version, CD owner/key)\n"
 	    "    -p PLR, --player=PLR        print stats for player PLR\n"
 	    "    --bnetd                     also print BNETD-specific stats\n"
 	    "    --fsgs                      also print FSGS-specific stats\n"
@@ -134,6 +135,7 @@ extern int main(int argc, char * argv[])
     int                use_fsgs=0;
     unsigned int       screen_width,screen_height;
     int                munged=0;
+    int                ignoreversion=0;
 
     if (argc<1 || !argv || !argv[0])
     {
@@ -332,6 +334,8 @@ extern int main(int argc, char * argv[])
 	else if (std::strcmp(argv[a],"-h")==0 || std::strcmp(argv[a],"--help")==0 || std::strcmp(argv[a],"--usage")
 ==0)
             usage(argv[0]);
+	else if (std::strcmp(argv[a],"-i")==0 || std::strcmp(argv[a],"--ignore-version")==0)
+            ignoreversion=1;
 	else if (std::strcmp(argv[a],"-v")==0 || std::strcmp(argv[a],"--version")==0)
 	{
             std::printf("version "PVPGN_VERSION"\n");
@@ -388,7 +392,7 @@ extern int main(int argc, char * argv[])
 	}
     }
 
-    if ((sd = client_connect(argv[0],servname,servport,cdowner,cdkey,clienttag,&saddr,&sessionkey,&sessionnum,ARCHTAG_WINX86,CLIENT_COUNTRYINFO_109_GAMELANG))<0)
+    if ((sd = client_connect(argv[0],servname,servport,cdowner,cdkey,clienttag,ignoreversion,&saddr,&sessionkey,&sessionnum,ARCHTAG_WINX86,CLIENT_COUNTRYINFO_109_GAMELANG))<0)
     {
 	std::fprintf(stderr,"%s: fatal error during handshake\n",argv[0]);
 	if (changed_in)

--- a/pvpgn/src/client/client_connect.cpp
+++ b/pvpgn/src/client/client_connect.cpp
@@ -142,6 +142,9 @@ int get_defversioninfo(char const * progname, char const * clienttag, unsigned i
     *exeinfo = "";
     *checksum = 0;
 
+    if (std::strcmp(clienttag,CLIENTTAG_BNCHATBOT)==0)
+	return 0;
+
     std::fprintf(stderr,"%s: unsupported clienttag \"%s\"\n",progname,clienttag);
     // aaron: dunno what we should return in case of this.. but returning nothing was definetly wrong
     return -1;
@@ -155,7 +158,7 @@ namespace pvpgn
 namespace client
 {
 
-extern int client_connect(char const * progname, char const * servname, unsigned short servport, char const * cdowner, char const * cdkey, char const * clienttag, struct sockaddr_in * saddr, unsigned int * sessionkey, unsigned int * sessionnum, char const * archtag, char const * gamelang)
+extern int client_connect(char const * progname, char const * servname, unsigned short servport, char const * cdowner, char const * cdkey, char const * clienttag, int ignoreversion, struct sockaddr_in * saddr, unsigned int * sessionkey, unsigned int * sessionnum, char const * archtag, char const * gamelang)
 {
     struct hostent * host;
     char const *     username;
@@ -329,6 +332,9 @@ extern int client_connect(char const * progname, char const * servname, unsigned
 	*sessionnum = bn_int_get(rpacket->u.server_authreq_109.sessionnum);
 	/* FIXME: also get filename and equation */
 
+	if (!ignoreversion)
+	{
+
 	if (!(packet = packet_create(packet_class_bnet)))
 	{
 	    std::fprintf(stderr,"%s: could not create packet\n",progname);
@@ -368,6 +374,7 @@ extern int client_connect(char const * progname, char const * servname, unsigned
       {
          std::fprintf(stderr,"AUTHREPLY_109 failed - closing connection\n");
          goto error_rpacket;
+      }
       }
     }
     else

--- a/pvpgn/src/client/client_connect.h
+++ b/pvpgn/src/client/client_connect.h
@@ -83,7 +83,7 @@ namespace pvpgn
 namespace client
 {
 
-extern int client_connect(char const * progname, char const * servname, unsigned short servport, char const * cdowner, char const * cdkey, char const * clienttag, struct sockaddr_in * saddr, unsigned int * sessionkey, unsigned int * sessionnum, char const * archtag, char const * gamelang);
+extern int client_connect(char const * progname, char const * servname, unsigned short servport, char const * cdowner, char const * cdkey, char const * clienttag, int ignoreversion, struct sockaddr_in * saddr, unsigned int * sessionkey, unsigned int * sessionnum, char const * archtag, char const * gamelang);
 
 }
 


### PR DESCRIPTION
This patch add option -i / --ignore-version in client_connect.cpp
which does not send game version information, cd owner and cd key
after SERVER_AUTHREQ_109 (like program bnbot).

When PvPGN server is configured to accept only war3 clients,
programs bnchat and bnstat could not connect to PvPGN server
without this patch.
